### PR TITLE
Remove max token duration constraint

### DIFF
--- a/jwtBearer.go
+++ b/jwtBearer.go
@@ -15,10 +15,6 @@ import (
 	"github.com/dgrijalva/jwt-go"
 )
 
-const (
-	maxTokenDuration = 3 * time.Minute
-)
-
 type jwtBearer struct {
 	// Underlying HTTP client used for making all HTTP requests to salesforce
 	// note that the configuration of this HTTP client will affect all HTTP
@@ -44,10 +40,6 @@ type jwtBearer struct {
 }
 
 func NewClientWithJWTBearer(sandbox bool, instanceURL, consumerKey, username string, privateKey []byte, tokenDuration time.Duration, httpClient http.Client) (Client, error) {
-	if tokenDuration > maxTokenDuration {
-		return nil, fmt.Errorf("tokenDuration must be less or equal to %s, got: %s", maxTokenDuration, tokenDuration)
-	}
-
 	jwtBearer := jwtBearer{
 		client:           httpClient,
 		instanceURL:      instanceURL,

--- a/jwtBearer_test.go
+++ b/jwtBearer_test.go
@@ -77,13 +77,6 @@ func TestNewClientWithJWTBearer(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "Error/TokenDurationTooBig",
-			args: args{
-				tokenDuration: 4 * time.Minute,
-			},
-			wantErr: true,
-		},
-		{
 			name: "Error/ParseRSAPrivateKeyFromPEM",
 			args: args{
 				isProd:        true,


### PR DESCRIPTION
While updating the `salesforce` service, we pulled in updates to this module which introduced a maximum allowed token duraction (https://github.com/nicheinc/sfdcclient/pull/2). This caused the service to fail when starting up (https://github.com/nicheinc/salesforce/issues/19). We want the token to be long lived enough to complete a salesforce sync. It is unclear what ideal token expiration is, but the default in the service 90 minutes. It seems unwise and unnecessary to set a constraint on the token duration in this client. More guidelines can be found at https://help.salesforce.com/s/articleView?id=sf.remoteaccess_oauth_jwt_flow.htm&type=5 if we feel we need more control around this point.